### PR TITLE
Updated icons

### DIFF
--- a/tasks/icons.js
+++ b/tasks/icons.js
@@ -28,13 +28,21 @@ task('delete-icons', () =>
 
 task('clean-icons', () =>
   src('node_modules/@a4u/a4u-spectrum-open-source/assets/*/*.svg')
-    .pipe(replace(/<defs>[\s\S]*?<\/defs>/m, ''))
-    .pipe(replace(/<title>[\s\S]*?<\/title>/m, ''))
+    
+    .pipe(replace(/class=\"fillPale\"/g, 'opacity="0.2"'))
+    .pipe(replace(/class=\"fillMedium\"/g, 'opacity="0.5"'))
     .pipe(svgmin({
       full: true,
       plugins: [
-        {
+        'inlineStyles',
+        'convertStyleToAttrs',
+        'removeStyleElement',
+        'removeEmptyContainers',
+        'removeTitle',
+
+        {  
           name: 'preset-default',
+          
           params: {
             overrides: {
               removeViewBox: false,
@@ -50,10 +58,11 @@ task('clean-icons', () =>
               'id',
               '*:fill:((?!^none$).)*'
             ]
-          }
-        }
+          } 
+        } 
       ]
     }))
+
     .pipe(rename(function (filePath) {
       filePath.basename = filePath.basename.replace(/S_(.*?)_.*/, '$1');
       filePath.dirname = filePath.dirname.split('_').pop();


### PR DESCRIPTION
Updated the gulp script to create transparencies for the lighter gray styles, and to preserve transparencies that are in the. icons.
This corrects now all gradient icons, the color wheel and the "Folder2Color" icon. 
And all future icons using the CSS ctyle ".fillMedium", ".fillpale" or any transparency.    
